### PR TITLE
Migrate actions-dependencies workflow to reusable workflow format

### DIFF
--- a/workflows/actions-dependencies.yml
+++ b/workflows/actions-dependencies.yml
@@ -1,0 +1,21 @@
+name: Submit Actions Dependencies
+on:
+  workflow_call:
+    inputs:
+      branches:
+        required: false
+        type: string
+      schedule:
+        required: false
+        type: string
+jobs:
+  submit-dependencies:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to read workflow files
+      id-token: write # Required for dependency submission
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jessehouwing/actions-dependency-submission@v0.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the submission of action dependencies. The workflow is designed to be reusable via `workflow_call` and leverages a third-party action for dependency submission.

New workflow for dependency submission:

* Added `workflows/actions-dependencies.yml` to define the "Submit Actions Dependencies" workflow, which can be triggered by other workflows using `workflow_call` and supports configurable `branches` and `schedule` inputs.
* The workflow uses `jessehouwing/actions-dependency-submission@v0.0.1` to submit dependencies, with appropriate permissions and secret token configuration.