### PR TITLE
Convert dependency-review and actionlint to reusable workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -2,6 +2,8 @@ name: Run Actionlint
 on: 
   pull_request:
     branches: main
+  
+  workflow_call:
     
 jobs:
   run-actionlint:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,6 +10,8 @@ on:
   
   pull_request:
   
+  workflow_call:
+  
 permissions:
   contents: read
 


### PR DESCRIPTION
This PR converts the `dependency-review` and `actionlint` workflows to reusable workflows that can be called by other repositories in the organization.

## Changes

- ✅ **Added** `workflow_call` trigger to `dependency-review.yml`
  - Enables other repos to use this as a reusable workflow
  - Maintains existing pull_request and workflow_dispatch triggers

- ✅ **Added** `workflow_call` trigger to `actionlint.yml`
  - Enables other repos to use this as a reusable workflow
  - Maintains existing pull_request trigger

## Benefits

- **Centralized maintenance**: Updates to these workflows only need to be made once
- **Consistency**: All repos using these workflows will have identical behavior
- **Reduced duplication**: Eliminates the need for each repo to maintain its own copy

## Related PRs

These new reusable workflows are being adopted by:
- actionlint (#146)
- azure-appservice-settings (#79)
- load-used-actions (#211)
- issue-comment-tag (#447)
- load-available-actions (#609)
- load-runner-info (#598)

## Testing

- The workflows maintain backward compatibility with existing functionality
- They use the same actions and configuration as the current implementations
- No breaking changes to existing behavior