### PR TITLE
Add workflow to validate npm token for GitHub Packages

### DIFF
--- a/.github/workflows/validate-npm-token.yml
+++ b/.github/workflows/validate-npm-token.yml
@@ -1,0 +1,38 @@
+name: Validate npm Token
+
+on:
+  workflow_dispatch:
+    inputs:
+      token:
+        description: 'GitHub token with read:packages scope to test (leave empty to use repo secret NPM_TOKEN)'
+        required: false
+        type: string
+
+  push:
+    paths:
+      - .github/workflows/validate-npm-token.yml
+
+permissions:
+  contents: read
+
+jobs:
+  validate-npm-token:
+    name: Validate npm token for GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
+        with:
+          egress-policy: audit
+
+      - name: Setup Node.js with GitHub Packages registry
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@devops-actions'
+
+      - name: Install @devops-actions/actions-marketplace-client
+        run: npm install @devops-actions/actions-marketplace-client
+        env:
+          NODE_AUTH_TOKEN: ${{ inputs.token != '' && inputs.token || secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a dedicated workflow to validate the npm token configured for installing `@devops-actions/actions-marketplace-client` from GitHub Packages.

## Problem

The job in [actions-marketplace-checks](https://github.com/rajbos/actions-marketplace-checks/actions/runs/24143047081/job/70560650824) keeps failing with:

```
npm error code E403
npm error 403 403 Forbidden - GET https://npm.pkg.github.com/@devops-actions%2factions-marketplace-client
npm error Permission permission_denied: The token provided does not match expected scopes.
```

This indicates the token used doesn't have `read:packages` scope.

## What this workflow does

- Triggers on `workflow_dispatch` (manual run) and on changes to the workflow file itself
- Configures the npm registry to use `https://npm.pkg.github.com` for the `@devops-actions` scope
- Runs `npm install @devops-actions/actions-marketplace-client` using the token from secret `NPM_TOKEN`
- The `workflow_dispatch` input also allows passing a token directly to test specific tokens ad-hoc

## How to use

1. Ensure the `NPM_TOKEN` secret is set in this repo with a token that has `read:packages` scope
2. Run the workflow manually via the Actions tab to confirm the token works
3. If the token is wrong/expired, generate a new PAT with `read:packages` and update the secret