### PR TITLE
fix: pin secure-action-inputs to v1.0.0 SHA instead of floating @main

### DIFF
--- a/.github/workflows/secure-inputs.yml
+++ b/.github/workflows/secure-inputs.yml
@@ -39,5 +39,4 @@ jobs:
         # - Variation Selectors Supplement (U+E0100-E01EF) — Glassworm attack vector
         # - BiDi overrides (Trojan Source), shell injection, template injection
         # - Prompt injection patterns targeting AI agents in CI/CD pipelines
-        # Pin to a specific SHA after the next release of secure-action-inputs.
-        uses: devops-actions/secure-action-inputs@main
+        uses: devops-actions/secure-action-inputs@e99fc0a00a1170cdab03c4a84b00e8c973ad28db # v1.0.0


### PR DESCRIPTION
Now that `devops-actions/secure-action-inputs` has a tagged `v1.0.0` release, this pins the reusable workflow's action reference by commit SHA (with version comment) instead of the floating `@main` branch ref.

**Why:** Dependabot's `github_actions` update checker requires at least one git tag on the referenced repo before it will compute a new commit SHA for updates (see `latest_commit_sha` in dependabot-core, which returns early when `latest_version_tag` is nil). A floating `@main` ref is also never tracked by Dependabot at all — it only updates SHA or tag pins.

**Related:** `devops-actions/.github` and `devops-actions/secure-action-inputs` both previously had zero tags, which is also why Dependabot never proposed updates to consumers' SHA-pinned `uses: devops-actions/.github/.github/workflows/secure-inputs.yml@<sha> # main` references. Both repos now have a `v1.0.0` tag/release to unblock that.
