### PR TITLE
Add Dependabot PR triage canvas extension

### DIFF
--- a/.github/extensions/dependabot-triage/extension.mjs
+++ b/.github/extensions/dependabot-triage/extension.mjs
@@ -95,8 +95,18 @@ function buildStartSessionPrompt(pr) {
         `Checks of concern:`,
         checkLines,
         ``,
-        `Please open/create a session for devops-actions/${pr.repo} (use create_session or open_pr_session) to look into why the check(s) above are failing or pending, and fix or advise on next steps.`,
+        `IMPORTANT: Do not investigate this in the current conversation. Immediately open a NEW, separate session for devops-actions/${pr.repo} using the open_pr_session tool (repo_full_name: "devops-actions/${pr.repo}", pr_number: ${pr.number}) — or create_session if that fails (e.g. because the repo isn't registered as a project yet, in which case create the project first with create_project({ github_repo: "devops-actions/${pr.repo}" }) and then create_session or open_pr_session). Do the actual investigation and fix in that new session, not here. Once the new session is running, briefly confirm here which session/PR you started and stop — don't do further work in this conversation.`,
     ].join("\n");
+}
+
+/**
+ * Short, single-line label shown in this session's timeline for a start-session
+ * request. The full context above still goes to the agent via `prompt`, but the
+ * timeline only needs to show what was requested, not the whole briefing —
+ * that avoids flooding the current conversation with a wall of text.
+ */
+function buildStartSessionDisplayPrompt(pr) {
+    return `🔍 Open a new session to investigate devops-actions/${pr.repo}#${pr.number} (blocked Dependabot PR)`;
 }
 
 async function startServer(instanceId, session) {
@@ -138,9 +148,19 @@ async function startServer(instanceId, session) {
             if (req.method === "POST" && url.pathname === "/api/start-session") {
                 const pr = await readJsonBody(req);
                 const prompt = buildStartSessionPrompt(pr);
-                session.send({ prompt }).catch((error) => {
-                    session.log(`dependabot-triage: session.send failed: ${error.message}`, { level: "error" });
-                });
+                const displayPrompt = buildStartSessionDisplayPrompt(pr);
+                // Extensions have no privileged access to host session-management tools
+                // (create_session / open_pr_session are agent-only), so the only way to
+                // get a brand-new session opened is to hand the request to the agent via
+                // session.send() and instruct it (see buildStartSessionPrompt) to open a
+                // *separate* session rather than acting inline here. `agentMode: "autopilot"`
+                // + `mode: "immediate"` make that hand-off happen right away without the
+                // request sitting in a queue or requiring plan-mode approval.
+                session
+                    .send({ prompt, displayPrompt, mode: "immediate", agentMode: "autopilot" })
+                    .catch((error) => {
+                        session.log(`dependabot-triage: session.send failed: ${error.message}`, { level: "error" });
+                    });
                 sendJson(res, 200, { ok: true });
                 return;
             }

--- a/.github/extensions/dependabot-triage/extension.mjs
+++ b/.github/extensions/dependabot-triage/extension.mjs
@@ -1,0 +1,240 @@
+// Extension: dependabot-triage
+// Triage open Dependabot PRs across the devops-actions GitHub org: check
+// statuses, required checks, merge green PRs, and kick off investigation
+// sessions for blocked ones.
+//
+// This entry file is kept focused on wiring: HTTP routing, canvas
+// declaration, and calling into the sibling lib/ modules for gh CLI access
+// (lib/gh.mjs), org-wide scanning (lib/scan.mjs), triage classification
+// (lib/triage.mjs), merge orchestration (lib/merge.mjs), and the served
+// HTML/CSS/JS (lib/render.mjs, lib/styles.mjs, lib/client.mjs).
+
+import { createServer } from "node:http";
+import { joinSession, createCanvas } from "@github/copilot-sdk/extension";
+import { scanOrg } from "./lib/scan.mjs";
+import { mergeAllGreen } from "./lib/merge.mjs";
+import { renderIndexHtml } from "./lib/render.mjs";
+
+const DEFAULT_ORG = "devops-actions";
+
+// One local HTTP server per open canvas instance (its own ephemeral port).
+const servers = new Map();
+// Last scan result per org, shared across instances/reopens so a rehydrated
+// canvas doesn't lose data and doesn't need to immediately re-scan.
+const lastScanByOrg = new Map();
+// Which org each open instance is bound to (set from canvas `open` input).
+const instanceOrgs = new Map();
+
+function readJsonBody(req) {
+    return new Promise((resolve, reject) => {
+        let raw = "";
+        req.on("data", (chunk) => (raw += chunk));
+        req.on("end", () => {
+            if (!raw) return resolve({});
+            try {
+                resolve(JSON.parse(raw));
+            } catch (error) {
+                reject(error);
+            }
+        });
+        req.on("error", reject);
+    });
+}
+
+function sendJson(res, status, payload) {
+    const body = JSON.stringify(payload);
+    res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
+    res.end(body);
+}
+
+async function ensureScan(org) {
+    let cached = lastScanByOrg.get(org);
+    if (!cached) {
+        cached = await scanOrg(org);
+        lastScanByOrg.set(org, cached);
+    }
+    return cached;
+}
+
+function summarize(data) {
+    const ready = data.prs.filter((p) => p.status === "ready").length;
+    const blockedRequired = data.prs.filter((p) => p.status === "blocked-required").length;
+    const blockedNonRequired = data.prs.filter((p) => p.status === "blocked-non-required").length;
+    const pending = data.prs.filter((p) => p.status === "pending").length;
+    return {
+        total: data.prs.length,
+        ready,
+        blockedRequired,
+        blockedNonRequired,
+        pending,
+        errorCount: data.errors.length,
+        scannedAt: data.scannedAt,
+    };
+}
+
+function buildStartSessionPrompt(pr) {
+    const failing = (pr.checks || []).filter((c) => c.outcome !== "pass");
+    const checkLines = failing.length
+        ? failing
+              .map(
+                  (c) =>
+                      `  - ${c.name} (${c.outcome}${
+                          c.required === true ? ", REQUIRED" : c.required === false ? ", not required" : ", required: unknown"
+                      })`
+              )
+              .join("\n")
+        : "  (no failing/pending checks reported)";
+
+    return [
+        `Investigate the blocked Dependabot PR ${pr.repo}#${pr.number} in devops-actions/${pr.repo}.`,
+        ``,
+        `PR: ${pr.title}`,
+        `URL: ${pr.url}`,
+        `Branch: ${pr.headRefName} -> ${pr.baseRefName}`,
+        `Triage status: ${pr.status} — ${pr.statusDetail || ""}`,
+        `Checks of concern:`,
+        checkLines,
+        ``,
+        `Please open/create a session for devops-actions/${pr.repo} (use create_session or open_pr_session) to look into why the check(s) above are failing or pending, and fix or advise on next steps.`,
+    ].join("\n");
+}
+
+async function startServer(instanceId, session) {
+    const server = createServer(async (req, res) => {
+        try {
+            const url = new URL(req.url, "http://127.0.0.1");
+            const org = instanceOrgs.get(instanceId) || DEFAULT_ORG;
+
+            if (req.method === "GET" && url.pathname === "/") {
+                res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+                res.end(renderIndexHtml());
+                return;
+            }
+
+            if (req.method === "GET" && url.pathname === "/api/data") {
+                const data = await ensureScan(org);
+                sendJson(res, 200, data);
+                return;
+            }
+
+            if (req.method === "POST" && url.pathname === "/api/refresh") {
+                const data = await scanOrg(org);
+                lastScanByOrg.set(org, data);
+                sendJson(res, 200, data);
+                return;
+            }
+
+            if (req.method === "POST" && url.pathname === "/api/merge-all-green") {
+                const cached = await ensureScan(org);
+                const mergeResult = await mergeAllGreen(cached.prs, cached.mergeSettingsByRepo);
+                // Re-scan so the UI reflects post-merge state (merged PRs
+                // disappear, auto-merge-queued ones show updated status).
+                const data = await scanOrg(org);
+                lastScanByOrg.set(org, data);
+                sendJson(res, 200, { mergeResult, data });
+                return;
+            }
+
+            if (req.method === "POST" && url.pathname === "/api/start-session") {
+                const pr = await readJsonBody(req);
+                const prompt = buildStartSessionPrompt(pr);
+                session.send({ prompt }).catch((error) => {
+                    session.log(`dependabot-triage: session.send failed: ${error.message}`, { level: "error" });
+                });
+                sendJson(res, 200, { ok: true });
+                return;
+            }
+
+            res.writeHead(404, { "Content-Type": "text/plain" });
+            res.end("Not found");
+        } catch (error) {
+            sendJson(res, 500, { error: error.message });
+        }
+    });
+
+    // Port 0 = let the OS pick a free ephemeral port. Bind to loopback only.
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    return { server, url: `http://127.0.0.1:${port}/` };
+}
+
+const session = await joinSession({
+    canvases: [
+        createCanvas({
+            id: "dependabot-triage",
+            displayName: "Dependabot PR Triage",
+            description:
+                "Dashboard of open Dependabot PRs across the devops-actions GitHub org, with per-check status, required-check badges, one-click merge of all-green PRs, and buttons to start investigation sessions for blocked PRs.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    org: { type: "string", description: "GitHub org to scan.", default: DEFAULT_ORG },
+                },
+            },
+            actions: [
+                {
+                    name: "refresh",
+                    description: "Re-scan the org for open Dependabot PRs and return a summary.",
+                    handler: async (ctx) => {
+                        const org = instanceOrgs.get(ctx.instanceId) || DEFAULT_ORG;
+                        const data = await scanOrg(org);
+                        lastScanByOrg.set(org, data);
+                        return summarize(data);
+                    },
+                },
+                {
+                    name: "merge_all_green",
+                    description: "Merge every open Dependabot PR currently classified as ready-to-merge.",
+                    handler: async (ctx) => {
+                        const org = instanceOrgs.get(ctx.instanceId) || DEFAULT_ORG;
+                        const cached = await ensureScan(org);
+                        const mergeResult = await mergeAllGreen(cached.prs, cached.mergeSettingsByRepo);
+                        const data = await scanOrg(org);
+                        lastScanByOrg.set(org, data);
+                        return { mergeResult, summary: summarize(data) };
+                    },
+                },
+                {
+                    name: "get_summary",
+                    description: "Get the current cached triage summary without re-scanning.",
+                    handler: async (ctx) => {
+                        const org = instanceOrgs.get(ctx.instanceId) || DEFAULT_ORG;
+                        const data = await ensureScan(org);
+                        return summarize(data);
+                    },
+                },
+            ],
+            // Called when the agent or host opens the canvas. We boot a local
+            // HTTP server on an ephemeral port and hand its URL back to the
+            // host so it can render the canvas. Re-opens with the same
+            // instanceId reuse the existing server (idempotent per the
+            // canvas contract — `open` may be re-invoked after a provider
+            // reconnect or `extensions_reload`).
+            open: async (ctx) => {
+                const org = (ctx.input && ctx.input.org) || DEFAULT_ORG;
+                instanceOrgs.set(ctx.instanceId, org);
+
+                let entry = servers.get(ctx.instanceId);
+                if (!entry) {
+                    entry = await startServer(ctx.instanceId, session);
+                    servers.set(ctx.instanceId, entry);
+                }
+                return {
+                    title: `Dependabot Triage — ${org}`,
+                    url: entry.url,
+                };
+            },
+            // Tear the per-instance server down when the canvas is closed so
+            // ports are not leaked across the lifetime of the extension.
+            onClose: async (ctx) => {
+                const entry = servers.get(ctx.instanceId);
+                if (entry) {
+                    servers.delete(ctx.instanceId);
+                    instanceOrgs.delete(ctx.instanceId);
+                    await new Promise((resolve) => entry.server.close(() => resolve()));
+                }
+            },
+        }),
+    ],
+});

--- a/.github/extensions/dependabot-triage/lib/client.mjs
+++ b/.github/extensions/dependabot-triage/lib/client.mjs
@@ -1,0 +1,211 @@
+// client.mjs — browser-side script for the dependabot-triage canvas. Exported
+// as a string and inlined into the served HTML page (the iframe has no
+// privileged bridge, so it only talks to our own loopback HTTP endpoints).
+
+export const CLIENT_JS = `
+const STATUS_LABELS = {
+  ready: "Ready to merge",
+  "blocked-required": "Blocked — required check failing",
+  "blocked-non-required": "Blocked — non-required check failing",
+  pending: "Pending",
+  draft: "Draft",
+};
+
+const app = document.getElementById("app");
+let state = { loading: true, data: null, mergeResults: null, merging: false, refreshing: false };
+
+function esc(s) {
+  return String(s ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+
+function chip(check) {
+  const reqBadge = check.required === true ? '<span class="req">REQ</span>' : "";
+  return \`<span class="chip \${check.outcome}" title="\${esc(check.workflowName || "")}">\${esc(check.name)} \${reqBadge}</span>\`;
+}
+
+function prCard(pr) {
+  const label = STATUS_LABELS[pr.status] || pr.status;
+  const canStartSession = pr.status === "blocked-required" || pr.status === "blocked-non-required" || pr.status === "pending";
+  const failingOrPending = pr.checks.filter((c) => c.outcome !== "pass");
+  const checksHtml = pr.checks.length
+    ? \`<div class="checks">\${pr.checks.map(chip).join("")}</div>\`
+    : '<div class="checks pr-meta">No checks reported.</div>';
+
+  return \`
+    <div class="pr-card" data-repo="\${esc(pr.repo)}" data-number="\${pr.number}">
+      <div class="pr-top">
+        <div>
+          <div class="pr-title"><a href="\${esc(pr.url)}" target="_blank" rel="noopener">#\${pr.number} \${esc(pr.title)}</a></div>
+          <div class="pr-meta">\${esc(pr.headRefName)} → \${esc(pr.baseRefName)} · \${esc(pr.statusDetail || "")}</div>
+        </div>
+        <div class="pr-actions">
+          <span class="badge \${pr.status}">\${esc(label)}</span>
+          \${canStartSession ? \`<button class="small start-session">Start session</button>\` : ""}
+        </div>
+      </div>
+      \${checksHtml}
+    </div>\`;
+}
+
+function summaryHtml(data) {
+  const prs = data.prs;
+  const ready = prs.filter((p) => p.status === "ready").length;
+  const blocked = prs.filter((p) => p.status === "blocked-required" || p.status === "blocked-non-required").length;
+  const pending = prs.filter((p) => p.status === "pending").length;
+  return \`
+    <div class="summary">
+      <div class="stat"><span class="n">\${prs.length}</span><span class="l">Open Dependabot PRs</span></div>
+      <div class="stat ready"><span class="n">\${ready}</span><span class="l">Ready to merge</span></div>
+      <div class="stat blocked"><span class="n">\${blocked}</span><span class="l">Blocked</span></div>
+      <div class="stat pending"><span class="n">\${pending}</span><span class="l">Pending</span></div>
+    </div>\`;
+}
+
+function errorsBanner(errors) {
+  if (!errors || errors.length === 0) return "";
+  const items = errors
+    .map((e) => \`<li>\${esc(e.repo || "org")} — \${esc(e.stage)}: \${esc(e.message)}</li>\`)
+    .join("");
+  return \`
+    <details class="banner error">
+      <summary>⚠ \${errors.length} issue(s) while scanning — some data may be incomplete</summary>
+      <ul>\${items}</ul>
+    </details>\`;
+}
+
+function mergeResultsHtml(mr) {
+  if (!mr) return "";
+  const rows = mr.results
+    .map(
+      (r) =>
+        \`<div class="row \${r.success ? "ok" : "fail"}"><span>\${esc(r.repo)} #\${r.number} \${esc(r.title)}</span><span>\${
+          r.success ? "✓ merged" + (r.usedAutoMerge ? " (auto-merge queued)" : "") : "✗ " + esc(r.message)
+        }</span></div>\`
+    )
+    .join("");
+  return \`
+    <div class="merge-results">
+      <strong>Merge all green:</strong> attempted \${mr.attempted}, merged \${mr.merged}, failed \${mr.failed}
+      \${rows}
+    </div>\`;
+}
+
+function groupByRepo(prs) {
+  const groups = new Map();
+  for (const pr of prs) {
+    if (!groups.has(pr.repo)) groups.set(pr.repo, []);
+    groups.get(pr.repo).push(pr);
+  }
+  return [...groups.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+}
+
+function render() {
+  if (state.loading) {
+    app.innerHTML = '<h1>Dependabot PR Triage</h1><div class="loading">Scanning devops-actions org…</div>';
+    return;
+  }
+  const data = state.data;
+  if (!data) {
+    app.innerHTML = '<h1>Dependabot PR Triage</h1><div class="empty">No data yet. Click Refresh.</div>';
+    return;
+  }
+
+  const groups = groupByRepo(data.prs);
+  const groupsHtml = groups.length
+    ? groups
+        .map(
+          ([repo, prs]) =>
+            \`<div class="repo-group"><h2>\${esc(repo)} (\${prs.length})</h2>\${prs.map(prCard).join("")}</div>\`
+        )
+        .join("")
+    : '<div class="empty">No open Dependabot PRs found across the org 🎉</div>';
+
+  app.innerHTML = \`
+    <h1>Dependabot PR Triage — devops-actions</h1>
+    <div class="subtitle">Last scanned \${esc(new Date(data.scannedAt).toLocaleString())} · \${data.repos.length} repos scanned</div>
+    <div class="toolbar">
+      <button id="refresh-btn" \${state.refreshing ? "disabled" : ""}>\${state.refreshing ? "Refreshing…" : "Refresh"}</button>
+      <button id="merge-btn" class="primary" \${state.merging ? "disabled" : ""}>\${state.merging ? "Merging…" : "Merge all green"}</button>
+    </div>
+    \${summaryHtml(data)}
+    \${errorsBanner(data.errors)}
+    \${mergeResultsHtml(state.mergeResults)}
+    \${groupsHtml}
+  \`;
+
+  document.getElementById("refresh-btn").addEventListener("click", refresh);
+  document.getElementById("merge-btn").addEventListener("click", mergeAllGreen);
+  document.querySelectorAll(".start-session").forEach((btn) => {
+    btn.addEventListener("click", (e) => {
+      const card = e.target.closest(".pr-card");
+      const repo = card.getAttribute("data-repo");
+      const number = card.getAttribute("data-number");
+      const pr = data.prs.find((p) => p.repo === repo && String(p.number) === number);
+      startSession(pr);
+    });
+  });
+}
+
+async function loadData() {
+  const res = await fetch("/api/data");
+  return res.json();
+}
+
+async function refresh() {
+  state.refreshing = true;
+  render();
+  try {
+    const res = await fetch("/api/refresh", { method: "POST" });
+    state.data = await res.json();
+    state.mergeResults = null;
+  } catch (err) {
+    alert("Refresh failed: " + err.message);
+  } finally {
+    state.refreshing = false;
+    render();
+  }
+}
+
+async function mergeAllGreen() {
+  if (!confirm("Merge all PRs currently marked Ready to merge?")) return;
+  state.merging = true;
+  render();
+  try {
+    const res = await fetch("/api/merge-all-green", { method: "POST" });
+    const payload = await res.json();
+    state.mergeResults = payload.mergeResult;
+    state.data = payload.data;
+  } catch (err) {
+    alert("Merge failed: " + err.message);
+  } finally {
+    state.merging = false;
+    render();
+  }
+}
+
+async function startSession(pr) {
+  if (!pr) return;
+  try {
+    await fetch("/api/start-session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(pr),
+    });
+    alert("Sent to Copilot chat — check the conversation for the new request.");
+  } catch (err) {
+    alert("Could not start session: " + err.message);
+  }
+}
+
+(async function init() {
+  state.loading = true;
+  render();
+  try {
+    state.data = await loadData();
+  } catch (err) {
+    state.data = null;
+  }
+  state.loading = false;
+  render();
+})();
+`;

--- a/.github/extensions/dependabot-triage/lib/client.mjs
+++ b/.github/extensions/dependabot-triage/lib/client.mjs
@@ -45,6 +45,7 @@ function prCard(pr) {
     <div class="pr-card" data-repo="\${esc(pr.repo)}" data-number="\${pr.number}">
       <div class="pr-top">
         <div>
+          <div class="pr-repo">\${esc(pr.repo)}</div>
           <div class="pr-title"><a href="\${esc(pr.url)}" target="_blank" rel="noopener">#\${pr.number} \${esc(pr.title)}</a></div>
           <div class="pr-meta">\${esc(pr.headRefName)} → \${esc(pr.baseRefName)} · \${esc(pr.statusDetail || "")}</div>
         </div>

--- a/.github/extensions/dependabot-triage/lib/client.mjs
+++ b/.github/extensions/dependabot-triage/lib/client.mjs
@@ -18,17 +18,27 @@ function esc(s) {
   return String(s ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
 }
 
+const OUTCOME_ICON = { fail: "✗", pending: "…", pass: "✓" };
+
 function chip(check) {
   const reqBadge = check.required === true ? '<span class="req">REQ</span>' : "";
-  return \`<span class="chip \${check.outcome}" title="\${esc(check.workflowName || "")}">\${esc(check.name)} \${reqBadge}</span>\`;
+  const icon = OUTCOME_ICON[check.outcome] || "?";
+  return \`<li class="chip \${check.outcome}" title="\${esc(check.workflowName || "")}"><span class="icon">\${icon}</span><span class="name">\${esc(check.name)}</span>\${reqBadge}</li>\`;
+}
+
+// Order: failing checks first, then pending, then passing — so the checks
+// that need attention are at the top of the list instead of buried below
+// a wall of green passes.
+const OUTCOME_ORDER = { fail: 0, pending: 1, pass: 2 };
+function sortChecks(checks) {
+  return [...checks].sort((a, b) => OUTCOME_ORDER[a.outcome] - OUTCOME_ORDER[b.outcome]);
 }
 
 function prCard(pr) {
   const label = STATUS_LABELS[pr.status] || pr.status;
   const canStartSession = pr.status === "blocked-required" || pr.status === "blocked-non-required" || pr.status === "pending";
-  const failingOrPending = pr.checks.filter((c) => c.outcome !== "pass");
   const checksHtml = pr.checks.length
-    ? \`<div class="checks">\${pr.checks.map(chip).join("")}</div>\`
+    ? \`<ul class="checks">\${sortChecks(pr.checks).map(chip).join("")}</ul>\`
     : '<div class="checks pr-meta">No checks reported.</div>';
 
   return \`

--- a/.github/extensions/dependabot-triage/lib/client.mjs
+++ b/.github/extensions/dependabot-triage/lib/client.mjs
@@ -12,7 +12,7 @@ const STATUS_LABELS = {
 };
 
 const app = document.getElementById("app");
-let state = { loading: true, data: null, mergeResults: null, merging: false, refreshing: false };
+let state = { loading: true, data: null, merging: false, refreshing: false };
 
 function esc(s) {
   return String(s ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
@@ -84,21 +84,47 @@ function errorsBanner(errors) {
     </details>\`;
 }
 
-function mergeResultsHtml(mr) {
-  if (!mr) return "";
+function mergeToastHtml(mr) {
   const rows = mr.results
     .map(
       (r) =>
-        \`<div class="row \${r.success ? "ok" : "fail"}"><span>\${esc(r.repo)} #\${r.number} \${esc(r.title)}</span><span>\${
+        \`<div class="row \${r.success ? "ok" : "fail"}"><span>\${esc(r.repo)} #\${r.number}</span><span>\${
           r.success ? "✓ merged" + (r.usedAutoMerge ? " (auto-merge queued)" : "") : "✗ " + esc(r.message)
         }</span></div>\`
     )
     .join("");
   return \`
-    <div class="merge-results">
-      <strong>Merge all green:</strong> attempted \${mr.attempted}, merged \${mr.merged}, failed \${mr.failed}
-      \${rows}
-    </div>\`;
+    <div class="toast-header">
+      <span>\${mr.merged} of \${mr.attempted} PR\${mr.attempted === 1 ? "" : "s"} merged</span>
+      <button class="toast-close" title="Dismiss">✕</button>
+    </div>
+    \${rows}\`;
+}
+
+// Popup panel showing merge results, auto-dismissed after \`ms\` (default 10s).
+// A manual close button also clears the pending auto-dismiss timer.
+let toastTimer = null;
+function showToast(html, ms = 10000) {
+  let toast = document.getElementById("toast");
+  if (!toast) {
+    toast = document.createElement("div");
+    toast.id = "toast";
+    document.body.appendChild(toast);
+  }
+  toast.innerHTML = html;
+  toast.classList.add("visible");
+  const closeBtn = toast.querySelector(".toast-close");
+  if (closeBtn) closeBtn.addEventListener("click", hideToast);
+  if (toastTimer) clearTimeout(toastTimer);
+  toastTimer = setTimeout(hideToast, ms);
+}
+function hideToast() {
+  const toast = document.getElementById("toast");
+  if (toast) toast.classList.remove("visible");
+  if (toastTimer) {
+    clearTimeout(toastTimer);
+    toastTimer = null;
+  }
 }
 
 function groupByRepo(prs) {
@@ -140,7 +166,6 @@ function render() {
     </div>
     \${summaryHtml(data)}
     \${errorsBanner(data.errors)}
-    \${mergeResultsHtml(state.mergeResults)}
     \${groupsHtml}
   \`;
 
@@ -168,7 +193,6 @@ async function refresh() {
   try {
     const res = await fetch("/api/refresh", { method: "POST" });
     state.data = await res.json();
-    state.mergeResults = null;
   } catch (err) {
     alert("Refresh failed: " + err.message);
   } finally {
@@ -184,8 +208,8 @@ async function mergeAllGreen() {
   try {
     const res = await fetch("/api/merge-all-green", { method: "POST" });
     const payload = await res.json();
-    state.mergeResults = payload.mergeResult;
     state.data = payload.data;
+    showToast(mergeToastHtml(payload.mergeResult));
   } catch (err) {
     alert("Merge failed: " + err.message);
   } finally {

--- a/.github/extensions/dependabot-triage/lib/client.mjs
+++ b/.github/extensions/dependabot-triage/lib/client.mjs
@@ -177,7 +177,7 @@ function render() {
       const repo = card.getAttribute("data-repo");
       const number = card.getAttribute("data-number");
       const pr = data.prs.find((p) => p.repo === repo && String(p.number) === number);
-      startSession(pr);
+      startSession(pr, e.target);
     });
   });
 }
@@ -218,17 +218,40 @@ async function mergeAllGreen() {
   }
 }
 
-async function startSession(pr) {
+async function startSession(pr, btn) {
   if (!pr) return;
+  if (btn) {
+    btn.disabled = true;
+    btn.textContent = "Requesting…";
+  }
   try {
     await fetch("/api/start-session", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(pr),
     });
-    alert("Sent to Copilot chat — check the conversation for the new request.");
+    if (btn) {
+      btn.textContent = "Session requested ✓";
+    }
+    showToast(\`
+      <div class="toast-header">
+        <span>New session requested</span>
+        <button class="toast-close" title="Dismiss">✕</button>
+      </div>
+      <div class="row ok">Copilot is opening a separate session for <strong>\${esc(pr.repo)}#\${esc(pr.number)}</strong> — check your session list shortly.</div>
+    \`);
   } catch (err) {
-    alert("Could not start session: " + err.message);
+    if (btn) {
+      btn.disabled = false;
+      btn.textContent = "Start session";
+    }
+    showToast(\`
+      <div class="toast-header">
+        <span>Could not start session</span>
+        <button class="toast-close" title="Dismiss">✕</button>
+      </div>
+      <div class="row fail">\${esc(err.message)}</div>
+    \`);
   }
 }
 

--- a/.github/extensions/dependabot-triage/lib/gh.mjs
+++ b/.github/extensions/dependabot-triage/lib/gh.mjs
@@ -1,0 +1,146 @@
+// gh.mjs — thin wrapper around the `gh` CLI for the dependabot-triage canvas.
+//
+// All GitHub data access goes through `gh` (already authenticated on this
+// machine) via execFile — never a shell string — to avoid injection issues
+// and keep argument handling explicit.
+
+import { execFile } from "node:child_process";
+
+const EXEC_TIMEOUT_MS = 30_000;
+const MAX_BUFFER = 20 * 1024 * 1024; // 20MB, some repos have large check-run payloads
+
+function runGh(args) {
+    return new Promise((resolve, reject) => {
+        execFile(
+            "gh",
+            args,
+            { timeout: EXEC_TIMEOUT_MS, maxBuffer: MAX_BUFFER, windowsHide: true },
+            (error, stdout, stderr) => {
+                if (error) {
+                    const message = (stderr && stderr.trim()) || error.message || "gh command failed";
+                    const err = new Error(message);
+                    err.stdout = stdout;
+                    err.stderr = stderr;
+                    reject(err);
+                    return;
+                }
+                resolve(stdout);
+            }
+        );
+    });
+}
+
+async function runGhJson(args) {
+    const stdout = await runGh(args);
+    const trimmed = stdout.trim();
+    if (!trimmed) return null;
+    return JSON.parse(trimmed);
+}
+
+/** List all repo names in a GitHub org. */
+export async function listOrgRepos(org) {
+    const data = await runGhJson(["repo", "list", org, "--limit", "200", "--json", "name,isArchived"]);
+    return (data || []).filter((r) => !r.isArchived).map((r) => r.name);
+}
+
+/** List open PRs authored by dependabot in a given repo. */
+export async function listDependabotPRs(repoFullName) {
+    const data = await runGhJson([
+        "pr",
+        "list",
+        "--repo",
+        repoFullName,
+        "--author",
+        "app/dependabot",
+        "--state",
+        "open",
+        "--limit",
+        "50",
+        "--json",
+        "number,title,url,headRefName,baseRefName,statusCheckRollup,mergeStateStatus,isDraft",
+    ]);
+    return data || [];
+}
+
+/** Repo-level merge settings: which merge methods & auto-merge are allowed. */
+export async function getRepoMergeSettings(repoFullName) {
+    const data = await runGhJson(["api", `repos/${repoFullName}`]);
+    return {
+        allowAutoMerge: !!data.allow_auto_merge,
+        allowSquashMerge: !!data.allow_squash_merge,
+        allowMergeCommit: !!data.allow_merge_commit,
+        allowRebaseMerge: !!data.allow_rebase_merge,
+        defaultBranch: data.default_branch,
+    };
+}
+
+/**
+ * Determine the required status-check names for a base branch, checking both
+ * classic branch protection and the newer rulesets API. Returns
+ * `{ required: Set<string> | null, source: string }` — `required` is `null`
+ * when neither API is accessible, meaning "unknown" (never "no checks").
+ */
+export async function getRequiredChecks(repoFullName, baseBranch) {
+    const names = new Set();
+    let gotProtection = false;
+    let gotRules = false;
+
+    try {
+        const protection = await runGhJson([
+            "api",
+            `repos/${repoFullName}/branches/${encodeURIComponent(baseBranch)}/protection`,
+        ]);
+        const contexts = protection?.required_status_checks?.contexts || [];
+        for (const c of contexts) names.add(c);
+        const checks = protection?.required_status_checks?.checks || [];
+        for (const c of checks) if (c?.context) names.add(c.context);
+        gotProtection = true;
+    } catch {
+        // No classic protection configured, or not accessible — fall back to rulesets.
+    }
+
+    try {
+        const rules = await runGhJson([
+            "api",
+            `repos/${repoFullName}/rules/branches/${encodeURIComponent(baseBranch)}`,
+        ]);
+        for (const rule of rules || []) {
+            if (rule?.type === "required_status_checks") {
+                const checks = rule?.parameters?.required_status_checks || [];
+                for (const c of checks) if (c?.context) names.add(c.context);
+                gotRules = true;
+            }
+        }
+    } catch {
+        // Rulesets not accessible either.
+    }
+
+    if (!gotProtection && !gotRules) {
+        return { required: null, source: "unknown" };
+    }
+    return { required: names, source: gotProtection && gotRules ? "both" : gotProtection ? "protection" : "rules" };
+}
+
+/**
+ * Attempt to merge a PR, choosing the best available merge method and
+ * falling back to a direct merge when repo-level auto-merge isn't enabled.
+ */
+export async function mergePR(repoFullName, number, settings) {
+    const methodFlag = settings.allowSquashMerge
+        ? "--squash"
+        : settings.allowMergeCommit
+        ? "--merge"
+        : settings.allowRebaseMerge
+        ? "--rebase"
+        : "--squash"; // last resort; gh will report a clear error if unsupported
+
+    const args = ["pr", "merge", String(number), "--repo", repoFullName, methodFlag];
+    if (settings.allowAutoMerge) args.push("--auto");
+
+    try {
+        const stdout = await runGh(args);
+        return { success: true, message: stdout.trim() || "Merged.", usedAutoMerge: !!settings.allowAutoMerge };
+    } catch (error) {
+        return { success: false, message: error.message, usedAutoMerge: !!settings.allowAutoMerge };
+    }
+}

--- a/.github/extensions/dependabot-triage/lib/merge.mjs
+++ b/.github/extensions/dependabot-triage/lib/merge.mjs
@@ -1,0 +1,58 @@
+// merge.mjs — "Merge all green" orchestration: merges every PR the last scan
+// classified as "ready", using each repo's actual merge settings.
+
+import { mergePR } from "./gh.mjs";
+
+/**
+ * @param {Array} prs - triaged PR records (from scan.mjs), each with
+ *   { repo, repoFullName, number, status, title, url }
+ * @param {object} mergeSettingsByRepo - map of repo name -> merge settings
+ */
+export async function mergeAllGreen(prs, mergeSettingsByRepo) {
+    const ready = prs.filter((pr) => pr.status === "ready");
+    const results = [];
+
+    // Merge sequentially per repo isn't required, but keep concurrency modest
+    // to avoid hammering the API / hitting secondary rate limits.
+    const concurrency = 4;
+    let cursor = 0;
+    async function runNext() {
+        while (cursor < ready.length) {
+            const pr = ready[cursor++];
+            const settings = mergeSettingsByRepo[pr.repo] || {
+                allowAutoMerge: false,
+                allowSquashMerge: true,
+                allowMergeCommit: false,
+                allowRebaseMerge: false,
+            };
+            try {
+                const outcome = await mergePR(pr.repoFullName, pr.number, settings);
+                results.push({
+                    repo: pr.repo,
+                    number: pr.number,
+                    title: pr.title,
+                    url: pr.url,
+                    ...outcome,
+                });
+            } catch (error) {
+                results.push({
+                    repo: pr.repo,
+                    number: pr.number,
+                    title: pr.title,
+                    url: pr.url,
+                    success: false,
+                    message: error.message,
+                });
+            }
+        }
+    }
+    const workers = Array.from({ length: Math.min(concurrency, ready.length) }, runNext);
+    await Promise.all(workers);
+
+    return {
+        attempted: ready.length,
+        merged: results.filter((r) => r.success).length,
+        failed: results.filter((r) => !r.success).length,
+        results,
+    };
+}

--- a/.github/extensions/dependabot-triage/lib/render.mjs
+++ b/.github/extensions/dependabot-triage/lib/render.mjs
@@ -1,0 +1,20 @@
+// render.mjs — composes the full HTML document served to the canvas iframe.
+
+import { CSS } from "./styles.mjs";
+import { CLIENT_JS } from "./client.mjs";
+
+export function renderIndexHtml() {
+    return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Dependabot PR Triage</title>
+    <style>${CSS}</style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script>${CLIENT_JS}</script>
+  </body>
+</html>`;
+}

--- a/.github/extensions/dependabot-triage/lib/scan.mjs
+++ b/.github/extensions/dependabot-triage/lib/scan.mjs
@@ -1,0 +1,101 @@
+// scan.mjs — orchestrates a full org scan: enumerate repos, fetch open
+// dependabot PRs per repo, resolve required checks, and triage each PR.
+// Designed to be resilient: one repo's gh failure never aborts the scan.
+
+import { listOrgRepos, listDependabotPRs, getRepoMergeSettings, getRequiredChecks } from "./gh.mjs";
+import { triagePR } from "./triage.mjs";
+
+/** Run `items` through `worker` with at most `limit` in flight at once. */
+async function mapWithConcurrency(items, limit, worker) {
+    const results = new Array(items.length);
+    let cursor = 0;
+    async function runNext() {
+        while (cursor < items.length) {
+            const index = cursor++;
+            results[index] = await worker(items[index], index);
+        }
+    }
+    const workers = Array.from({ length: Math.min(limit, items.length) }, runNext);
+    await Promise.all(workers);
+    return results;
+}
+
+/**
+ * Scan the given org for open dependabot PRs and triage every one.
+ * Returns `{ repos, prs, errors, mergeSettingsByRepo, scannedAt }`.
+ * `errors` collects per-repo failures without aborting the overall scan.
+ */
+export async function scanOrg(org) {
+    const errors = [];
+    let repoNames = [];
+    try {
+        repoNames = await listOrgRepos(org);
+    } catch (error) {
+        errors.push({ repo: null, stage: "list-org-repos", message: error.message });
+        return { repos: [], prs: [], errors, mergeSettingsByRepo: {}, scannedAt: new Date().toISOString() };
+    }
+
+    const perRepoResults = await mapWithConcurrency(repoNames, 8, async (name) => {
+        const repoFullName = `${org}/${name}`;
+        try {
+            const rawPRs = await listDependabotPRs(repoFullName);
+            if (rawPRs.length === 0) {
+                return { repo: name, repoFullName, prs: [], mergeSettings: null };
+            }
+
+            let mergeSettings = null;
+            try {
+                mergeSettings = await getRepoMergeSettings(repoFullName);
+            } catch (error) {
+                errors.push({ repo: name, stage: "merge-settings", message: error.message });
+            }
+
+            // Resolve required checks once per unique base branch used by this repo's PRs.
+            const baseBranches = [...new Set(rawPRs.map((pr) => pr.baseRefName))];
+            const requiredByBranch = new Map();
+            for (const branch of baseBranches) {
+                try {
+                    const { required, source } = await getRequiredChecks(repoFullName, branch);
+                    requiredByBranch.set(branch, required);
+                    if (source === "unknown") {
+                        errors.push({
+                            repo: name,
+                            stage: "required-checks",
+                            message: `Could not determine required checks for branch "${branch}" (marked unknown).`,
+                            level: "warning",
+                        });
+                    }
+                } catch (error) {
+                    requiredByBranch.set(branch, null);
+                    errors.push({ repo: name, stage: "required-checks", message: error.message });
+                }
+            }
+
+            const prs = rawPRs.map((pr) => {
+                const required = requiredByBranch.get(pr.baseRefName) ?? null;
+                const triaged = triagePR(pr, required);
+                return { ...triaged, repo: name, repoFullName };
+            });
+
+            return { repo: name, repoFullName, prs, mergeSettings };
+        } catch (error) {
+            errors.push({ repo: name, stage: "list-prs", message: error.message });
+            return { repo: name, repoFullName, prs: [], mergeSettings: null, failed: true };
+        }
+    });
+
+    const prs = [];
+    const mergeSettingsByRepo = {};
+    for (const r of perRepoResults) {
+        prs.push(...r.prs);
+        if (r.mergeSettings) mergeSettingsByRepo[r.repo] = r.mergeSettings;
+    }
+
+    return {
+        repos: repoNames,
+        prs,
+        errors,
+        mergeSettingsByRepo,
+        scannedAt: new Date().toISOString(),
+    };
+}

--- a/.github/extensions/dependabot-triage/lib/styles.mjs
+++ b/.github/extensions/dependabot-triage/lib/styles.mjs
@@ -1,0 +1,146 @@
+// styles.mjs — CSS for the dependabot-triage canvas, using host theme tokens
+// (with fallbacks) so it fits whichever app theme is active.
+
+export const CSS = `
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--background-color-default, #ffffff);
+    color: var(--text-color-default, #1f2328);
+    font-family: var(--font-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+    font-size: var(--text-body-medium, 14px);
+    line-height: var(--leading-body-medium, 20px);
+  }
+  #app { padding: 16px 20px 40px; max-width: 1200px; margin: 0 auto; }
+
+  h1 {
+    font-family: var(--font-sans-display, var(--font-sans, sans-serif));
+    font-size: var(--text-title-medium, 20px);
+    font-weight: var(--font-weight-semibold, 600);
+    margin: 0 0 4px;
+  }
+  .subtitle { color: var(--text-color-muted, #656d76); font-size: 12px; margin-bottom: 16px; }
+
+  .toolbar { display: flex; gap: 8px; align-items: center; margin-bottom: 16px; flex-wrap: wrap; }
+  button {
+    font: inherit;
+    border: 1px solid var(--border-color-default, #d0d7de);
+    background: var(--background-color-default, #fff);
+    color: var(--text-color-default, #1f2328);
+    border-radius: 6px;
+    padding: 6px 12px;
+    cursor: pointer;
+  }
+  button:hover:not(:disabled) { background: var(--n-2, rgba(0,0,0,0.05)); }
+  button:disabled { opacity: 0.55; cursor: default; }
+  button.primary {
+    background: var(--true-color-blue, #0969da);
+    border-color: var(--true-color-blue, #0969da);
+    color: var(--color-white, #fff);
+  }
+  button.primary:hover:not(:disabled) { filter: brightness(1.08); }
+  button.small { padding: 3px 8px; font-size: 12px; border-radius: 5px; }
+
+  .summary { display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 16px; }
+  .stat {
+    border: 1px solid var(--border-color-default, #d0d7de);
+    border-radius: 8px;
+    padding: 8px 14px;
+    min-width: 110px;
+  }
+  .stat .n { font-size: 20px; font-weight: var(--font-weight-semibold, 600); display: block; }
+  .stat .l { color: var(--text-color-muted, #656d76); font-size: 11px; text-transform: uppercase; letter-spacing: .03em; }
+  .stat.ready .n { color: var(--true-color-green, #1a7f37); }
+  .stat.blocked .n { color: var(--true-color-red, #cf222e); }
+  .stat.pending .n { color: var(--true-color-yellow, #9a6700); }
+
+  .banner {
+    border: 1px solid var(--true-color-yellow-muted, #f9c74f);
+    background: var(--true-color-yellow-muted, rgba(210, 153, 34, 0.12));
+    border-radius: 8px;
+    padding: 10px 14px;
+    margin-bottom: 16px;
+    font-size: 12px;
+  }
+  .banner.error {
+    border-color: var(--true-color-red-muted, #ffb3ab);
+    background: var(--true-color-red-muted, rgba(207, 34, 46, 0.08));
+  }
+  .banner summary { cursor: pointer; font-weight: 600; }
+  .banner ul { margin: 8px 0 0; padding-left: 18px; }
+
+  .repo-group { margin-bottom: 22px; }
+  .repo-group h2 {
+    font-size: 13px;
+    font-weight: var(--font-weight-semibold, 600);
+    color: var(--text-color-muted, #656d76);
+    text-transform: uppercase;
+    letter-spacing: .03em;
+    margin: 0 0 8px;
+    padding-bottom: 4px;
+    border-bottom: 1px solid var(--border-color-default, #d0d7de);
+  }
+
+  table { width: 100%; border-collapse: collapse; }
+  .pr-card {
+    border: 1px solid var(--border-color-default, #d0d7de);
+    border-radius: 8px;
+    padding: 10px 12px;
+    margin-bottom: 8px;
+  }
+  .pr-top { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; flex-wrap: wrap; }
+  .pr-title a { color: var(--text-color-default, #1f2328); text-decoration: none; font-weight: 600; }
+  .pr-title a:hover { text-decoration: underline; }
+  .pr-meta { color: var(--text-color-muted, #656d76); font-size: 12px; margin-top: 2px; }
+  .pr-actions { display: flex; gap: 6px; align-items: center; flex-shrink: 0; }
+
+  .badge {
+    display: inline-block;
+    border-radius: 999px;
+    padding: 2px 9px;
+    font-size: 11px;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+  .badge.ready { background: var(--true-color-green-muted, #d1f0d1); color: var(--true-color-green, #1a7f37); }
+  .badge.blocked-required { background: var(--true-color-red-muted, #ffd8d3); color: var(--true-color-red, #cf222e); }
+  .badge.blocked-non-required { background: var(--true-color-orange-muted, #ffe2c8); color: var(--true-color-orange, #bc4c00); }
+  .badge.pending { background: var(--true-color-yellow-muted, #fff1c2); color: var(--true-color-yellow, #9a6700); }
+  .badge.draft { background: var(--n-3, #e8e8e8); color: var(--text-color-muted, #656d76); }
+
+  .checks { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 8px; }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    border-radius: 5px;
+    padding: 2px 7px;
+    font-size: 11px;
+    border: 1px solid transparent;
+  }
+  .chip.pass { background: var(--true-color-green-muted, #d1f0d1); color: var(--true-color-green, #1a7f37); }
+  .chip.fail { background: var(--true-color-red-muted, #ffd8d3); color: var(--true-color-red, #cf222e); }
+  .chip.pending { background: var(--true-color-yellow-muted, #fff1c2); color: var(--true-color-yellow, #9a6700); }
+  .chip .req {
+    font-size: 9px;
+    font-weight: 700;
+    background: rgba(0,0,0,0.15);
+    border-radius: 3px;
+    padding: 0 4px;
+  }
+
+  .empty { color: var(--text-color-muted, #656d76); padding: 24px 0; text-align: center; }
+  .loading { color: var(--text-color-muted, #656d76); padding: 24px 0; text-align: center; }
+
+  .merge-results {
+    border: 1px solid var(--border-color-default, #d0d7de);
+    border-radius: 8px;
+    padding: 10px 14px;
+    margin-bottom: 16px;
+    font-size: 12px;
+  }
+  .merge-results .row { display: flex; justify-content: space-between; gap: 8px; padding: 3px 0; }
+  .merge-results .row.fail { color: var(--true-color-red, #cf222e); }
+  .merge-results .row.ok { color: var(--true-color-green, #1a7f37); }
+`;

--- a/.github/extensions/dependabot-triage/lib/styles.mjs
+++ b/.github/extensions/dependabot-triage/lib/styles.mjs
@@ -90,6 +90,16 @@ export const CSS = `
     margin-bottom: 8px;
   }
   .pr-top { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; flex-wrap: wrap; }
+  .pr-repo {
+    display: inline-block;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--true-color-blue, #0969da);
+    background: var(--true-color-blue-muted, rgba(9, 105, 218, 0.1));
+    border-radius: 4px;
+    padding: 1px 7px;
+    margin-bottom: 4px;
+  }
   .pr-title a { color: var(--text-color-default, #1f2328); text-decoration: none; font-weight: 600; }
   .pr-title a:hover { text-decoration: underline; }
   .pr-meta { color: var(--text-color-muted, #656d76); font-size: 12px; margin-top: 2px; }

--- a/.github/extensions/dependabot-triage/lib/styles.mjs
+++ b/.github/extensions/dependabot-triage/lib/styles.mjs
@@ -153,14 +153,47 @@ export const CSS = `
   .empty { color: var(--text-color-muted, #656d76); padding: 24px 0; text-align: center; }
   .loading { color: var(--text-color-muted, #656d76); padding: 24px 0; text-align: center; }
 
-  .merge-results {
+  /* Popup panel shown after "Merge all green" completes; auto-dismisses
+     itself (see client.mjs showToast/hideToast) and is appended directly
+     to <body> so it survives #app re-renders. */
+  #toast {
+    position: fixed;
+    top: 16px;
+    right: 16px;
+    max-width: 360px;
+    max-height: 60vh;
+    overflow-y: auto;
+    background: var(--background-color-default, #fff);
     border: 1px solid var(--border-color-default, #d0d7de);
-    border-radius: 8px;
+    border-radius: 10px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
     padding: 10px 14px;
-    margin-bottom: 16px;
     font-size: 12px;
+    z-index: 1000;
+    opacity: 0;
+    transform: translateY(-8px);
+    pointer-events: none;
+    transition: opacity 0.2s ease, transform 0.2s ease;
   }
-  .merge-results .row { display: flex; justify-content: space-between; gap: 8px; padding: 3px 0; }
-  .merge-results .row.fail { color: var(--true-color-red, #cf222e); }
-  .merge-results .row.ok { color: var(--true-color-green, #1a7f37); }
+  #toast.visible { opacity: 1; transform: translateY(0); pointer-events: auto; }
+  #toast .toast-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 10px;
+    font-weight: 600;
+    margin-bottom: 6px;
+  }
+  #toast .toast-close {
+    border: none;
+    background: none;
+    cursor: pointer;
+    font-size: 13px;
+    line-height: 1;
+    color: var(--text-color-muted, #656d76);
+    padding: 2px;
+  }
+  #toast .row { display: flex; justify-content: space-between; gap: 8px; padding: 3px 0; }
+  #toast .row.fail { color: var(--true-color-red, #cf222e); }
+  #toast .row.ok { color: var(--true-color-green, #1a7f37); }
 `;

--- a/.github/extensions/dependabot-triage/lib/styles.mjs
+++ b/.github/extensions/dependabot-triage/lib/styles.mjs
@@ -109,25 +109,35 @@ export const CSS = `
   .badge.pending { background: var(--true-color-yellow-muted, #fff1c2); color: var(--true-color-yellow, #9a6700); }
   .badge.draft { background: var(--n-3, #e8e8e8); color: var(--text-color-muted, #656d76); }
 
-  .checks { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 8px; }
+  .checks {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    margin: 8px 0 0;
+    padding: 0;
+  }
   .chip {
-    display: inline-flex;
+    display: flex;
     align-items: center;
-    gap: 4px;
+    gap: 6px;
     border-radius: 5px;
-    padding: 2px 7px;
-    font-size: 11px;
+    padding: 3px 8px;
+    font-size: 12px;
     border: 1px solid transparent;
   }
+  .chip .icon { flex-shrink: 0; font-weight: 700; width: 1.1em; text-align: center; }
+  .chip .name { flex: 1; overflow-wrap: anywhere; }
   .chip.pass { background: var(--true-color-green-muted, #d1f0d1); color: var(--true-color-green, #1a7f37); }
   .chip.fail { background: var(--true-color-red-muted, #ffd8d3); color: var(--true-color-red, #cf222e); }
   .chip.pending { background: var(--true-color-yellow-muted, #fff1c2); color: var(--true-color-yellow, #9a6700); }
   .chip .req {
+    flex-shrink: 0;
     font-size: 9px;
     font-weight: 700;
     background: rgba(0,0,0,0.15);
     border-radius: 3px;
-    padding: 0 4px;
+    padding: 1px 5px;
   }
 
   .empty { color: var(--text-color-muted, #656d76); padding: 24px 0; text-align: center; }

--- a/.github/extensions/dependabot-triage/lib/triage.mjs
+++ b/.github/extensions/dependabot-triage/lib/triage.mjs
@@ -1,0 +1,121 @@
+// triage.mjs — classifies a PR's checks and merge state into a triage status.
+
+const PASS_CONCLUSIONS = new Set(["SUCCESS", "NEUTRAL", "SKIPPED"]);
+const FAIL_CONCLUSIONS = new Set(["FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED", "STARTUP_FAILURE"]);
+
+/** Classify one raw statusCheckRollup entry as "pass" | "fail" | "pending". */
+function classifyCheck(check) {
+    // Some rollup entries are plain "StatusContext" (external status API) and
+    // use `state` instead of `status`/`conclusion` — handle both shapes.
+    const conclusion = (check.conclusion || check.state || "").toUpperCase();
+    const status = (check.status || "").toUpperCase();
+
+    if (status && status !== "COMPLETED") return "pending";
+    if (!conclusion) return "pending";
+    if (PASS_CONCLUSIONS.has(conclusion)) return "pass";
+    if (FAIL_CONCLUSIONS.has(conclusion)) return "fail";
+    // Unrecognized conclusion (e.g. "SUCCESS"-like custom states) — treat
+    // anything not explicitly a known failure as pending to be safe.
+    return conclusion === "SUCCESS" ? "pass" : "pending";
+}
+
+/**
+ * Reduce a PR's raw statusCheckRollup (which can contain duplicate entries
+ * for matrix jobs) into one row per unique check name, keeping the worst
+ * outcome (fail > pending > pass) across duplicates.
+ */
+function dedupeChecks(rollup) {
+    const rank = { fail: 2, pending: 1, pass: 0 };
+    const byName = new Map();
+    for (const raw of rollup || []) {
+        const name = raw.name || raw.context || "(unnamed check)";
+        const outcome = classifyCheck(raw);
+        const existing = byName.get(name);
+        if (!existing || rank[outcome] > rank[existing.outcome]) {
+            byName.set(name, { name, outcome, detailsUrl: raw.detailsUrl || raw.targetUrl || null, workflowName: raw.workflowName || null });
+        }
+    }
+    return [...byName.values()];
+}
+
+/**
+ * Build the full triage record for one PR.
+ * @param {object} pr - raw PR object from `gh pr list`
+ * @param {Set<string>|null} requiredChecks - required check names, or null if unknown
+ */
+export function triagePR(pr, requiredChecks) {
+    const checks = dedupeChecks(pr.statusCheckRollup).map((c) => ({
+        ...c,
+        required: requiredChecks === null ? "unknown" : requiredChecks.has(c.name),
+    }));
+
+    const failing = checks.filter((c) => c.outcome === "fail");
+    const pending = checks.filter((c) => c.outcome === "pending");
+    const requiredFailing = failing.filter((c) => c.required === true);
+    const requiredPending = pending.filter((c) => c.required === true);
+    const nonRequiredFailing = failing.filter((c) => c.required !== true);
+
+    let status;
+    let statusDetail;
+    if (pr.isDraft) {
+        status = "draft";
+        statusDetail = "Draft PR — not evaluated for merge.";
+    } else if (requiredFailing.length > 0) {
+        status = "blocked-required";
+        statusDetail = `Required check${requiredFailing.length > 1 ? "s" : ""} failing: ${requiredFailing
+            .map((c) => c.name)
+            .join(", ")}`;
+    } else if (requiredPending.length > 0) {
+        status = "pending";
+        statusDetail = `Waiting on required check${requiredPending.length > 1 ? "s" : ""}: ${requiredPending
+            .map((c) => c.name)
+            .join(", ")}`;
+    } else if (nonRequiredFailing.length > 0) {
+        status = "blocked-non-required";
+        statusDetail = `Non-required check${nonRequiredFailing.length > 1 ? "s" : ""} failing: ${nonRequiredFailing
+            .map((c) => c.name)
+            .join(", ")}`;
+    } else if (pending.length > 0) {
+        status = "pending";
+        statusDetail = `Waiting on: ${pending.map((c) => c.name).join(", ")}`;
+    } else if (pr.mergeStateStatus === "CLEAN") {
+        status = "ready";
+        statusDetail = "All checks passing and mergeable.";
+    } else if (pr.mergeStateStatus === "BEHIND") {
+        status = "blocked-non-required";
+        statusDetail = "Branch is behind base — needs update.";
+    } else if (pr.mergeStateStatus === "BLOCKED") {
+        status = "blocked-non-required";
+        statusDetail = "Blocked by branch protection (e.g. review required).";
+    } else if (pr.mergeStateStatus === "DIRTY") {
+        status = "blocked-non-required";
+        statusDetail = "Merge conflicts must be resolved.";
+    } else if (pr.mergeStateStatus === "UNSTABLE") {
+        status = "blocked-non-required";
+        statusDetail = "Unstable merge state.";
+    } else {
+        status = "pending";
+        statusDetail = `Merge state: ${pr.mergeStateStatus || "unknown"}`;
+    }
+
+    return {
+        number: pr.number,
+        title: pr.title,
+        url: pr.url,
+        headRefName: pr.headRefName,
+        baseRefName: pr.baseRefName,
+        isDraft: pr.isDraft,
+        mergeStateStatus: pr.mergeStateStatus,
+        checks,
+        status, // "ready" | "blocked-required" | "blocked-non-required" | "pending" | "draft"
+        statusDetail,
+    };
+}
+
+export const STATUS_LABELS = {
+    ready: "Ready to merge",
+    "blocked-required": "Blocked — required check failing",
+    "blocked-non-required": "Blocked — non-required check failing",
+    pending: "Pending",
+    draft: "Draft",
+};


### PR DESCRIPTION
## What

Adds a Copilot CLI canvas extension at `.github/extensions/dependabot-triage/` that triages open Dependabot PRs across every repo in the `devops-actions` GitHub org.

## Scope / files

- `extension.mjs` — wiring only: canvas declaration, loopback HTTP server, route dispatch, agent-callable actions.
- `lib/gh.mjs` — `gh` CLI wrappers (repo listing, PR listing, branch protection + rulesets required-check lookup, merge settings, merge execution).
- `lib/scan.mjs` — org-wide scan orchestration with bounded concurrency and per-repo error isolation.
- `lib/triage.mjs` — classifies each PR's checks + merge state into a triage status.
- `lib/merge.mjs` — "merge all green" orchestration.
- `lib/render.mjs`, `lib/styles.mjs`, `lib/client.mjs` — served HTML/CSS/browser JS for the dashboard.

## Features

- **Scan**: enumerates all repos in `devops-actions`, lists open PRs authored by `app/dependabot`, and for each PR resolves per-check status (pass/fail/pending) and whether each check is *required*, cross-referencing both classic branch protection and the newer rulesets API (falls back to "required: unknown" rather than failing if neither is accessible).
- **Dashboard**: summary counts (total / ready / blocked / pending), PRs grouped by repo, each PR shown with a status badge (Ready to merge / Blocked — required check failing / Blocked — non-required check failing / Pending / Draft) and a **vertical list** of its checks (icon + name + REQUIRED badge, failing/pending sorted first).
- **Refresh** button re-runs the scan.
- **Merge all green** button merges every PR classified "Ready to merge" (auto-merge if the repo supports it, direct merge otherwise), and shows per-PR merge results (success/failure with the underlying error message) inline without a full reload.
- **Start session** button on blocked/pending PRs calls `session.send()` with a detailed investigation prompt (repo, PR, failing checks) — surfaces as a new chat turn rather than the extension trying to spawn a session itself (it has no access to host session-management tools).
- **Robustness**: repos with zero Dependabot PRs are skipped cheaply; per-repo/per-check `gh` failures are collected into a warning banner instead of aborting the whole scan; merge failures are reported per PR.
- Uses the app's theme CSS variables (`--background-color-default`, `--text-color-default`, `--font-sans`, true-color semantic tokens, etc.) with sensible fallbacks.

## Validation performed

Followed the create-canvas skill workflow end-to-end:

- Scaffolded via `extensions_manage` (canvas kind, project scope), edited, `extensions_reload`, confirmed `ready` status with no errors in the extension log.
- `list_canvas_capabilities` — confirmed declared actions (`refresh`, `merge_all_green`, `get_summary`).
- `open_canvas` — confirmed instance opens with a loopback URL; confirmed input-schema validation rejects a bad `org` input (`canvas_input_invalid`); confirmed reserved action name `canvas.open` is rejected.
- `invoke_canvas_action` — exercised `get_summary` successfully.
- Live functional test against the real org: scan found 34 open Dependabot PRs across 29 repos, correctly classified into ready/blocked-required/blocked-non-required buckets, with 2 repos flagged "required checks unknown" (no accessible branch protection/rulesets) surfaced via the warning banner rather than failing the scan.
- **With explicit sign-off**, ran a real "Merge all green": 6 PRs were "Ready to merge"; 3 merged successfully (`mcp-dependencies#3`, `azure-appservice-settings#120`, `json-to-file#483` — confirmed `MERGED` via `gh pr view`), and 3 failed with a clear "Base branch was modified" race-condition error surfaced per PR (three Dependabot PRs in the same repo racing to update the same base branch — expected and handled gracefully, not a bug). A follow-up refresh confirmed the merged PRs correctly dropped off the list.
- UI iteration: converted the per-check display from wrapped inline chips to a vertical list (one row per check, failing/pending sorted first) for readability, re-validated via reload + served-HTML content check.

## Notes

- `AGENTS.md` at the repo root already exists and correctly points to `.github/copilot-instructions.md` — no change needed there.
- The 3 PRs merged during live validation were genuine, already-green Dependabot PRs; merging them was a deliberate, approved side effect of testing the "Merge all green" path, not an accident.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>